### PR TITLE
Improve sddp initialization

### DIFF
--- a/src/SDDPoptimize.jl
+++ b/src/SDDPoptimize.jl
@@ -110,6 +110,7 @@ function run_SDDP!(model::SPModel,
             (display > 0) && println("Prune cuts ...")
             remove_redundant_cuts!(V)
             prune_cuts!(model, param, V)
+            problems = hotstart_SDDP(model, param, V)
         end
 
         if (display > 0) && (iteration_count%display==0)

--- a/src/SDDPoptimize.jl
+++ b/src/SDDPoptimize.jl
@@ -306,7 +306,6 @@ function initialize_value_functions(model::SPModel,
                                     param::SDDPparameters)
 
     solverProblems = build_models(model, param)
-    solverProblems_null = build_models(model, param)
 
     V = Array{PolyhedralFunction}(model.stageNumber)
 
@@ -323,9 +322,10 @@ function initialize_value_functions(model::SPModel,
 
     stockTrajectories = forward_simulations(model,
                         param,
-                        solverProblems_null,
+                        solverProblems,
                         aleas,
                         true)[2]
+
 
     backward_pass!(model,
                   param,

--- a/src/SDDPoptimize.jl
+++ b/src/SDDPoptimize.jl
@@ -321,11 +321,10 @@ function initialize_value_functions(model::SPModel,
         model.finalCost(model, solverProblems[end])
     end
 
-    stockTrajectories = forward_simulations(model,
-                        param,
-                        solverProblems,
-                        aleas,
-                        true)[2]
+    stockTrajectories = zeros(model.stageNumber, param.forwardPassNumber, model.dimStates)
+    for i in 1:model.stageNumber, j in 1:param.forwardPassNumber
+        stockTrajectories[i, j, :] = get_random_state(model)
+    end
 
 
     backward_pass!(model,

--- a/src/forwardBackwardIterations.jl
+++ b/src/forwardBackwardIterations.jl
@@ -73,27 +73,28 @@ function forward_simulations(model::SPModel,
             state_t = extract_vector_from_3Dmatrix(stocks, t, k)
             alea_t = extract_vector_from_3Dmatrix(xi, t, k)
 
-            status, nextstep = solve_one_step_one_alea(
+            if ~init
+                status, nextstep = solve_one_step_one_alea(
                                             model,
                                             param,
                                             solverProblems[t],
                                             t,
                                             state_t,
-                                            alea_t,
-                                            init)
-
-            if status
-                stocks[t+1, k, :] = nextstep.next_state
-                opt_control = nextstep.optimal_control
-                controls[t, k, :] = opt_control
-                costs[k] += nextstep.cost - nextstep.cost_to_go
-                if t==T-1
-                    costs[k] += nextstep.cost_to_go
+                                            alea_t)
+                if status
+                    stocks[t+1, k, :] = nextstep.next_state
+                    opt_control = nextstep.optimal_control
+                    controls[t, k, :] = opt_control
+                    costs[k] += nextstep.cost - nextstep.cost_to_go
+                    if t==T-1
+                        costs[k] += nextstep.cost_to_go
+                    end
+                else
+                    stocks[t+1, k, :] = state_t
                 end
             else
-                stocks[t+1, k, :] = state_t
+                stocks[t+1, k, :] = [model.xlim[i][1] + rand()*(model.xlim[i][2] - model.xlim[i][1]) for i in 1:model.dimStates]
             end
-
         end
     end
     return costs, stocks, controls

--- a/src/forwardBackwardIterations.jl
+++ b/src/forwardBackwardIterations.jl
@@ -93,7 +93,7 @@ function forward_simulations(model::SPModel,
                     stocks[t+1, k, :] = state_t
                 end
             else
-                stocks[t+1, k, :] = [model.xlim[i][1] + rand()*(model.xlim[i][2] - model.xlim[i][1]) for i in 1:model.dimStates]
+                stocks[t+1, k, :] = get_random_state(model)
             end
         end
     end

--- a/src/oneStepOneAleaProblem.jl
+++ b/src/oneStepOneAleaProblem.jl
@@ -56,19 +56,12 @@ function solve_one_step_one_alea(model,
     # Update value of w:
     setvalue(w, xi)
 
-    # If this is the first call to the solver, value-to-go are approximated
-    # with null function:
-    if init
-        @constraint(m, alpha >= 0)
-    end
     # Update constraint x == xt
     for i in 1:model.dimStates
         JuMP.setRHS(m.ext[:cons][i], xt[i])
     end
 
-
     status = solve(m)
-
     solved = (status == :Optimal)
 
     if solved

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -111,6 +111,21 @@ end
 
 
 """
+Generate a random state.
+
+# Arguments
+* `model::SPModel`:
+
+# Return
+`Vector{Float64}`, shape=`(model.dimStates,)`
+
+"""
+function get_random_state(model)
+    return [model.xlim[i][1] + rand()*(model.xlim[i][2] - model.xlim[i][1]) for i in 1:model.dimStates]
+end
+
+
+"""
 Estimate the upper bound with a distribution of costs
 
 # Description


### PR DESCRIPTION
Generate first scenarios randomly to init SDDP

**UPDATE**: Perform the random generation directly in `initialize_value_functions` instead of `forward_pass`
