### PR TITLE
[UPD] Use collect instead of extract_vector_from_3Dmatrix

### DIFF
--- a/src/forwardBackwardIterations.jl
+++ b/src/forwardBackwardIterations.jl
@@ -66,8 +66,8 @@ function forward_simulations(model::SPModel,
     for t=1:T-1
         for k = 1:nb_forward
 
-            state_t = extract_vector_from_3Dmatrix(stocks, t, k)
-            alea_t = extract_vector_from_3Dmatrix(xi, t, k)
+            state_t = collect(stocks[t, k, :])
+            alea_t = collect(xi[t, k, :])
 
             status, nextstep = solve_one_step_one_alea(
                                         model,
@@ -186,7 +186,7 @@ function backward_pass!(model::SPModel,
         for k = 1:nb_forward
 
             subgradient_array = zeros(Float64, model.dimStates, law[t].supportSize)
-            state_t = extract_vector_from_3Dmatrix(stockTrajectories, t, k)
+            state_t = collect(stockTrajectories[t, k, :])
             proba = zeros(law[t].supportSize)
 
             for w in 1:law[t].supportSize

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,7 +104,7 @@ Extract a vector stored in a 3D Array
 function extract_vector_from_3Dmatrix(input_array::Array{Float64, 3},
                                       nx::Int64,
                                       ny::Int64)
-
+    info("extract_vector_from_3Dmatrix is now deprecated. Use collect instead.")
     state_dimension = size(input_array)[3]
     return reshape(input_array[nx, ny, :], state_dimension)
 end


### PR DESCRIPTION
The goal is to be more idiomatic and to remove some overhead. 

Memory allocation and execution time remain the same. 
