### PR TITLE
[FIX] Fix forgot collect in forward simulation grids

### DIFF
--- a/src/SDPoptimize.jl
+++ b/src/SDPoptimize.jl
@@ -541,6 +541,9 @@ function sdp_forward_single_simulation(model::StochDynProgModel,
     #Compute cartesian product spaces
     product_states, product_controls = generate_grid(model, param)
 
+    product_states = collect(product_states)
+    product_controls = collect(product_controls)
+
     controls = Inf*ones(TF-1, 1, model.dimControls)
     states = Inf*ones(TF, 1, model.dimStates)
 


### PR DESCRIPTION
This PR is a small fix for SDP. I forgot to collect product states and controls in forward simulations which was causing abnormally slow forward simulations. 

Julia v0.5 introduces Base.product which is better than Iterators.product and allows to use iterators without collecting. I tested and there is a slight speedup of value functions generation. However we cannot use @sync with a for loop over a Base.prod then we would have to update parallelization method. And using Base.product breaks the package for 0.4 users.

The package seems fully compatible with v0.5
